### PR TITLE
Allowed `DoctrineSchemaRegistry::getMetadata` to work with table name argument

### DIFF
--- a/src/contracts/Gateway/DoctrineSchemaMetadataRegistryInterface.php
+++ b/src/contracts/Gateway/DoctrineSchemaMetadataRegistryInterface.php
@@ -14,14 +14,14 @@ namespace Ibexa\Contracts\CorePersistence\Gateway;
 interface DoctrineSchemaMetadataRegistryInterface
 {
     /**
-     * @return array<class-string>
+     * @phpstan-return array<class-string|non-empty-string>
      */
     public function getAvailableMetadata(): array;
 
     /**
-     * @param class-string $className
+     * @phpstan-param non-empty-string|class-string $classOrTableName
      */
-    public function getMetadata(string $className): DoctrineSchemaMetadataInterface;
+    public function getMetadata(string $classOrTableName): DoctrineSchemaMetadataInterface;
 
     /**
      * @param class-string $className
@@ -32,4 +32,9 @@ interface DoctrineSchemaMetadataRegistryInterface
      * @param non-empty-string $tableName
      */
     public function getMetadataForTable(string $tableName): DoctrineSchemaMetadataInterface;
+
+    /**
+     * @param class-string $className
+     */
+    public function getMetadataForClass(string $className): DoctrineSchemaMetadataInterface;
 }

--- a/tests/lib/Gateway/DoctrineSchemaMetadataRegistryTest.php
+++ b/tests/lib/Gateway/DoctrineSchemaMetadataRegistryTest.php
@@ -8,22 +8,120 @@ declare(strict_types=1);
 
 namespace Ibexa\Tests\CorePersistence\Gateway;
 
+use Ibexa\Contracts\CorePersistence\Gateway\DoctrineSchemaMetadataInterface;
+use Ibexa\Contracts\CorePersistence\Gateway\GatewayInterface;
 use Ibexa\CorePersistence\Gateway\DoctrineSchemaMetadataRegistry;
 use LogicException;
 use PHPUnit\Framework\TestCase;
 
 final class DoctrineSchemaMetadataRegistryTest extends TestCase
 {
-    public function testGetMetadataForTable(): void
-    {
-        $registry = new DoctrineSchemaMetadataRegistry([]);
+    private DoctrineSchemaMetadataRegistry $registry;
 
+    protected function setUp(): void
+    {
+        $this->registry = new DoctrineSchemaMetadataRegistry([
+            $this->createGateway($this->createMetadata('foo', 'Foo')),
+            $this->createGateway($this->createMetadata('bar')),
+        ]);
+    }
+
+    public function testGetMetadataForTableFailure(): void
+    {
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage(
-            'Failed to find metadata for table "foo". '
+            'Failed to find classToMetadata for table "nonexistent". '
             . 'Did you forget to tag your gateway with "ibexa.core.persistence.doctrine_gateway" tag?'
         );
 
-        $registry->getMetadataForTable('foo');
+        $this->registry->getMetadataForTable('nonexistent');
+    }
+
+    public function testGetMetadataForClassFailure(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage(
+            'Failed to find classToMetadata for class "stdClass". '
+            . 'Did you forget to tag your gateway with "ibexa.core.persistence.doctrine_gateway" tag?'
+        );
+
+        $this->registry->getMetadataForClass('stdClass');
+    }
+
+    public function testGetMetadataFailure(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage(
+            'Failed to find classToMetadata for table or class "nonexistent". '
+            . 'Did you forget to tag your gateway with "ibexa.core.persistence.doctrine_gateway" tag?'
+        );
+
+        $this->registry->getMetadata('nonexistent');
+    }
+
+    public function testGetMetadata(): void
+    {
+        /** @phpstan-var class-string $classString */
+        $classString = 'Foo';
+
+        $metadata = $this->registry->getMetadata('foo');
+        self::assertSame('foo', $metadata->getTableName());
+        self::assertSame($classString, $metadata->getClassName());
+
+        $metadata = $this->registry->getMetadata($classString);
+        self::assertSame('foo', $metadata->getTableName());
+        self::assertSame($classString, $metadata->getClassName());
+
+        $metadata = $this->registry->getMetadata('bar');
+        self::assertSame('bar', $metadata->getTableName());
+        self::assertNull($metadata->getClassName());
+    }
+
+    public function testGetMetadataForTable(): void
+    {
+        /** @phpstan-var class-string $classString */
+        $classString = 'Foo';
+
+        $metadata = $this->registry->getMetadataForTable('foo');
+        self::assertSame('foo', $metadata->getTableName());
+        self::assertSame($classString, $metadata->getClassName());
+
+        $metadata = $this->registry->getMetadataForTable('bar');
+        self::assertSame('bar', $metadata->getTableName());
+        self::assertNull($metadata->getClassName());
+    }
+
+    public function testGetMetadataForClass(): void
+    {
+        /** @phpstan-var class-string $classString */
+        $classString = 'Foo';
+
+        $metadata = $this->registry->getMetadataForClass($classString);
+        self::assertSame('foo', $metadata->getTableName());
+        self::assertSame($classString, $metadata->getClassName());
+    }
+
+    /**
+     * @return \Ibexa\Contracts\CorePersistence\Gateway\GatewayInterface<array<mixed>>
+     */
+    private function createGateway(DoctrineSchemaMetadataInterface $metadata): GatewayInterface
+    {
+        $gateway = $this->createMock(GatewayInterface::class);
+
+        $gateway
+            ->method('getMetadata')
+            ->willReturn($metadata);
+
+        return $gateway;
+    }
+
+    private function createMetadata(string $tableName, ?string $className = null): DoctrineSchemaMetadataInterface
+    {
+        $mock = $this->createMock(DoctrineSchemaMetadataInterface::class);
+
+        $mock->method('getTableName')->willReturn($tableName);
+        $mock->method('getClassName')->willReturn($className);
+
+        return $mock;
     }
 }

--- a/tests/lib/Gateway/DoctrineSchemaMetadataRegistryTest.php
+++ b/tests/lib/Gateway/DoctrineSchemaMetadataRegistryTest.php
@@ -30,7 +30,7 @@ final class DoctrineSchemaMetadataRegistryTest extends TestCase
     {
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage(
-            'Failed to find classToMetadata for table "nonexistent". '
+            'Failed to find metadata for table "nonexistent". '
             . 'Did you forget to tag your gateway with "ibexa.core.persistence.doctrine_gateway" tag?'
         );
 
@@ -41,7 +41,7 @@ final class DoctrineSchemaMetadataRegistryTest extends TestCase
     {
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage(
-            'Failed to find classToMetadata for class "stdClass". '
+            'Failed to find metadata for class "stdClass". '
             . 'Did you forget to tag your gateway with "ibexa.core.persistence.doctrine_gateway" tag?'
         );
 
@@ -52,7 +52,7 @@ final class DoctrineSchemaMetadataRegistryTest extends TestCase
     {
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage(
-            'Failed to find classToMetadata for table or class "nonexistent". '
+            'Failed to find metadata for table or class "nonexistent". '
             . 'Did you forget to tag your gateway with "ibexa.core.persistence.doctrine_gateway" tag?'
         );
 


### PR DESCRIPTION
| Question                 | Answer                                              |
|--------------------------|-----------------------------------------------------|
| **JIRA issue**           | N/A |
| **Type**                 | improvement                             |
| **Target Ibexa version** | `v4.6`              |
| **BC breaks**            | no                                              |

This PR changes `DoctrineSchemaRegistry::getMetadata()` method to return metadata based on table name too.

Previously this was possible via unused `DoctrineSchemaRegistry::getMetadataByTableName()` method.

Initial design of core persistence was to have all metadata be accompanied with a class or interface name, so that it resembles ORM design. However, it has been shown that on multiple occasions relationships (which is where `DoctrineSchemaRegistry::getMetadata()` is primarily used) oftentimes work with schema's that have no object representation directly.

#### Checklist:

- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping for example `@ibexa/php-dev` for back-end changes and/or `@ibexa/javascript-dev` for
  front-end changes).
