### PR TITLE
Allowed Composite NOT expression

### DIFF
--- a/src/lib/Gateway/ExpressionVisitor.php
+++ b/src/lib/Gateway/ExpressionVisitor.php
@@ -210,12 +210,10 @@ final class ExpressionVisitor extends BaseExpressionVisitor
             case CompositeExpression::TYPE_OR:
                 return (string)$this->expr()->or(...$expressionList);
 
-            default:
-                // Multiversion support for `doctrine/collections` before and after v2.1.0
-                if (defined(CompositeExpression::class . '::TYPE_NOT') && $expr->getType() === CompositeExpression::TYPE_NOT) {
-                    return $this->queryBuilder->getConnection()->getDatabasePlatform()->getNotExpression($expressionList[0]);
-                }
+            case 'NOT':
+                return $this->queryBuilder->getConnection()->getDatabasePlatform()->getNotExpression($expressionList[0]);
 
+            default:
                 throw new RuntimeException('Unknown composite ' . $expr->getType());
         }
     }

--- a/tests/bundle/Gateway/ExpressionVisitorTest.php
+++ b/tests/bundle/Gateway/ExpressionVisitorTest.php
@@ -1,0 +1,104 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Bundle\CorePersistence\Gateway;
+
+use Doctrine\Common\Collections\Expr\Comparison;
+use Doctrine\Common\Collections\Expr\CompositeExpression;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Query\Expression\ExpressionBuilder;
+use Doctrine\DBAL\Query\QueryBuilder;
+use Ibexa\Contracts\CorePersistence\Gateway\DoctrineSchemaMetadataRegistryInterface;
+use Ibexa\CorePersistence\Gateway\ExpressionVisitor;
+use Ibexa\CorePersistence\Gateway\Parameter;
+use PHPUnit\Framework\TestCase;
+
+final class ExpressionVisitorTest extends TestCase
+{
+    private ExpressionVisitor $expressionVisitor;
+
+    protected function setUp(): void
+    {
+        $connection = $this->createMock(Connection::class);
+
+        $connection->method('getExpressionBuilder')
+            ->willReturn(new ExpressionBuilder($connection));
+
+        $platform = $this->getMockBuilder(AbstractPlatform::class)
+            ->getMockForAbstractClass();
+
+        $connection->method('getDatabasePlatform')
+            ->willReturn($platform);
+
+        $this->expressionVisitor = new ExpressionVisitor(
+            new QueryBuilder($connection),
+            $this->createMock(DoctrineSchemaMetadataRegistryInterface::class),
+            'table_name',
+            'table_alias',
+        );
+    }
+
+    public function testWalkComparison(): void
+    {
+        $result = $this->expressionVisitor->dispatch(new Comparison('field', '=', 'value'));
+
+        self::assertSame('table_alias.field = :field_0', $result);
+        self::assertEquals([
+            new Parameter(
+                'field_0',
+                'value',
+                0,
+            ),
+        ], $this->expressionVisitor->getParameters());
+    }
+
+    public function testLogicalNot(): void
+    {
+        $result = $this->expressionVisitor->dispatch(
+            new CompositeExpression('NOT', [new Comparison('field', '=', 'value')]),
+        );
+
+        self::assertSame('NOT(table_alias.field = :field_0)', $result);
+        self::assertEquals([
+            new Parameter(
+                'field_0',
+                'value',
+                0,
+            ),
+        ], $this->expressionVisitor->getParameters());
+    }
+
+    public function testLogicalAnd(): void
+    {
+        $result = $this->expressionVisitor->dispatch(
+            new CompositeExpression('AND', [
+                new Comparison('field', '=', 'value'),
+                new Comparison('field_2', 'IN', 'value_2'),
+            ]),
+        );
+
+        self::assertSame(
+            '(table_alias.field = :field_0) AND (table_alias.field_2 IN (:field_2_1))',
+            $result,
+        );
+
+        self::assertEquals([
+            new Parameter(
+                'field_0',
+                'value',
+                0,
+            ),
+            new Parameter(
+                'field_2_1',
+                'value_2',
+                0,
+            ),
+        ], $this->expressionVisitor->getParameters());
+    }
+}


### PR DESCRIPTION
| Question                 | Answer                                              |
|--------------------------|-----------------------------------------------------|
| **JIRA issue**           | N/A |
| **Type**                 | feature                             |
| **Target Ibexa version** | `v4.6`
| **BC breaks**            | no                                              |

This PR adds the ability for Core Persistence to work with `CompositeExpression` with `NOT` type.

https://github.com/doctrine/orm/blob/081ec2ad26ad3351799acd16e2bc4bd5d7e80c77/lib/Doctrine/ORM/Persisters/SqlExpressionVisitor.php#L86-L88

:point_up: above behavior is mimicked, since I don't think we have a specified `doctrine/collections` dependency?

Additionally, the const used in the Doctrine library exists only in 2.x version, which is PHP 8+.

#### Checklist:

- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping for example `@ibexa/php-dev` for back-end changes and/or `@ibexa/javascript-dev` for
  front-end changes).
