### PR TITLE
IBX-6824: Fixed doctrine metadata property/foreign key relationship methods

### DIFF
--- a/src/contracts/Exception/MappingException.php
+++ b/src/contracts/Exception/MappingException.php
@@ -10,7 +10,7 @@ namespace Ibexa\Contracts\CorePersistence\Exception;
 
 use Exception;
 
-final class MappingException extends Exception
+final class MappingException extends Exception implements MappingExceptionInterface
 {
     public static function singleIdNotAllowedOnCompositePrimaryKey(): self
     {

--- a/src/contracts/Exception/MappingExceptionInterface.php
+++ b/src/contracts/Exception/MappingExceptionInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Ibexa\Contracts\CorePersistence\Exception;
+
+use Throwable;
+
+interface MappingExceptionInterface extends Throwable
+{
+}

--- a/src/contracts/Exception/MappingExceptionInterface.php
+++ b/src/contracts/Exception/MappingExceptionInterface.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
 namespace Ibexa\Contracts\CorePersistence\Exception;
 
 use Throwable;

--- a/src/contracts/Exception/RuntimeMappingException.php
+++ b/src/contracts/Exception/RuntimeMappingException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Ibexa\Contracts\CorePersistence\Exception;
+
+use RuntimeException;
+
+final class RuntimeMappingException extends RuntimeException implements RuntimeMappingExceptionInterface
+{
+}

--- a/src/contracts/Exception/RuntimeMappingException.php
+++ b/src/contracts/Exception/RuntimeMappingException.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
 namespace Ibexa\Contracts\CorePersistence\Exception;
 
 use RuntimeException;

--- a/src/contracts/Exception/RuntimeMappingExceptionInterface.php
+++ b/src/contracts/Exception/RuntimeMappingExceptionInterface.php
@@ -1,10 +1,15 @@
 <?php
 
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
 namespace Ibexa\Contracts\CorePersistence\Exception;
 
 use Throwable;
 
 interface RuntimeMappingExceptionInterface extends Throwable
 {
-
 }

--- a/src/contracts/Exception/RuntimeMappingExceptionInterface.php
+++ b/src/contracts/Exception/RuntimeMappingExceptionInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Ibexa\Contracts\CorePersistence\Exception;
+
+use Throwable;
+
+interface RuntimeMappingExceptionInterface extends Throwable
+{
+
+}

--- a/src/contracts/Gateway/DoctrineSchemaMetadata.php
+++ b/src/contracts/Gateway/DoctrineSchemaMetadata.php
@@ -400,7 +400,7 @@ class DoctrineSchemaMetadata implements DoctrineSchemaMetadataInterface
         return $this->propertyToRelationship[$foreignProperty];
     }
 
-    public function getRelationshipByForeignColumn(string $foreignColumn): DoctrineRelationshipInterface
+    public function getRelationshipByForeignKeyColumn(string $foreignColumn): DoctrineRelationshipInterface
     {
         if (!isset($this->columnToRelationship[$foreignColumn])) {
             throw new RuntimeMappingException(sprintf(

--- a/src/contracts/Gateway/DoctrineSchemaMetadata.php
+++ b/src/contracts/Gateway/DoctrineSchemaMetadata.php
@@ -11,9 +11,7 @@ namespace Ibexa\Contracts\CorePersistence\Gateway;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Types\Type;
 use Ibexa\Contracts\CorePersistence\Exception\MappingException;
-use InvalidArgumentException;
-use LogicException;
-use RuntimeException;
+use Ibexa\Contracts\CorePersistence\Exception\RuntimeMappingException;
 
 /**
  * @internal
@@ -121,9 +119,6 @@ class DoctrineSchemaMetadata implements DoctrineSchemaMetadataInterface
         return $this->columnTypeCache[$column];
     }
 
-    /**
-     * @throws \Doctrine\DBAL\Exception
-     */
     private function resolveColumnType(string $column): Type
     {
         if (isset($this->columnToTypesMap[$column])) {
@@ -172,7 +167,7 @@ class DoctrineSchemaMetadata implements DoctrineSchemaMetadataInterface
             );
         }
 
-        throw new InvalidArgumentException(sprintf(
+        throw new RuntimeMappingException(sprintf(
             'Column "%s" does not exist in "%s" table. Available columns: "%s"',
             $column,
             $this->getTableName(),
@@ -211,9 +206,6 @@ class DoctrineSchemaMetadata implements DoctrineSchemaMetadataInterface
         return $this->getInheritanceMetadataWithColumn($column) !== null;
     }
 
-    /**
-     * @throws \Ibexa\Contracts\CorePersistence\Exception\MappingException
-     */
     public function getIdentifierColumn(): string
     {
         if (count($this->identifierColumns) > 1) {
@@ -293,7 +285,7 @@ class DoctrineSchemaMetadata implements DoctrineSchemaMetadataInterface
     public function getTranslationSchemaMetadata(): TranslationDoctrineSchemaMetadataInterface
     {
         if (!isset($this->translationMetadata)) {
-            throw new LogicException(sprintf(
+            throw new RuntimeMappingException(sprintf(
                 '%s does not contain translation metadata. Ensure that %1$s::%s has been called.',
                 DoctrineSchemaMetadata::class,
                 'setTranslationSchemaMetadata',
@@ -321,7 +313,7 @@ class DoctrineSchemaMetadata implements DoctrineSchemaMetadataInterface
     public function getSubclassByDiscriminator(string $discriminator): DoctrineSchemaMetadataInterface
     {
         if (empty($this->discriminatorMap)) {
-            throw new RuntimeException(sprintf(
+            throw new RuntimeMappingException(sprintf(
                 '"%s" is not registered as a subclass for table "%s". There are no registered subclasses',
                 $discriminator,
                 $this->getTableName(),
@@ -329,7 +321,7 @@ class DoctrineSchemaMetadata implements DoctrineSchemaMetadataInterface
         }
 
         if (!isset($this->discriminatorMap[$discriminator])) {
-            throw new RuntimeException(sprintf(
+            throw new RuntimeMappingException(sprintf(
                 '"%s" is not registered as a subclass for table "%s". Available discriminators: "%s"',
                 $discriminator,
                 $this->getTableName(),
@@ -352,7 +344,7 @@ class DoctrineSchemaMetadata implements DoctrineSchemaMetadataInterface
     {
         $this->inheritanceType = self::INHERITANCE_TYPE_JOINED;
         if (isset($this->discriminatorMap[$discriminator])) {
-            throw new LogicException(sprintf(
+            throw new MappingException(sprintf(
                 '"%s" is already added as a discriminator for a subtype.',
                 $discriminator,
             ));
@@ -370,7 +362,7 @@ class DoctrineSchemaMetadata implements DoctrineSchemaMetadataInterface
     {
         $foreignProperty = $relationship->getForeignProperty();
         if (isset($this->propertyToRelationship[$foreignProperty])) {
-            throw new LogicException(sprintf(
+            throw new MappingException(sprintf(
                 '"%s" is already added as foreign property.',
                 $foreignProperty,
             ));
@@ -380,7 +372,7 @@ class DoctrineSchemaMetadata implements DoctrineSchemaMetadataInterface
 
         $foreignColumn = $relationship->getForeignKeyColumn();
         if (isset($this->columnToRelationship[$foreignColumn])) {
-            throw new LogicException(sprintf(
+            throw new MappingException(sprintf(
                 '"%s" is already added as foreign column.',
                 $foreignColumn,
             ));
@@ -397,7 +389,7 @@ class DoctrineSchemaMetadata implements DoctrineSchemaMetadataInterface
     public function getRelationshipByForeignProperty(string $foreignProperty): DoctrineRelationshipInterface
     {
         if (!isset($this->propertyToRelationship[$foreignProperty])) {
-            throw new InvalidArgumentException(sprintf(
+            throw new RuntimeMappingException(sprintf(
                 '"%s" does not exist as a relationship for "%s" class metadata. Available relationship property: "%s"',
                 $foreignProperty,
                 $this->className,
@@ -411,7 +403,7 @@ class DoctrineSchemaMetadata implements DoctrineSchemaMetadataInterface
     public function getRelationshipByForeignColumn(string $foreignColumn): DoctrineRelationshipInterface
     {
         if (!isset($this->columnToRelationship[$foreignColumn])) {
-            throw new InvalidArgumentException(sprintf(
+            throw new RuntimeMappingException(sprintf(
                 '"%s" does not exist as a relationship for "%s" class metadata. Available relationship columns: "%s"',
                 $foreignColumn,
                 $this->className,

--- a/src/contracts/Gateway/DoctrineSchemaMetadataInterface.php
+++ b/src/contracts/Gateway/DoctrineSchemaMetadataInterface.php
@@ -154,5 +154,5 @@ interface DoctrineSchemaMetadataInterface
     /**
      * @throws \Ibexa\Contracts\CorePersistence\Exception\RuntimeMappingExceptionInterface
      */
-    public function getRelationshipByForeignColumn(string $foreignColumn): DoctrineRelationshipInterface;
+    public function getRelationshipByForeignKeyColumn(string $foreignColumn): DoctrineRelationshipInterface;
 }

--- a/src/contracts/Gateway/DoctrineSchemaMetadataInterface.php
+++ b/src/contracts/Gateway/DoctrineSchemaMetadataInterface.php
@@ -34,6 +34,9 @@ interface DoctrineSchemaMetadataInterface
      */
     public function getTableName(): string;
 
+    /**
+     * @throws \Ibexa\Contracts\CorePersistence\Exception\RuntimeMappingExceptionInterface
+     */
     public function getColumnType(string $column): Type;
 
     /**
@@ -43,6 +46,9 @@ interface DoctrineSchemaMetadataInterface
 
     public function hasColumn(string $column): bool;
 
+    /**
+     * @throws \Ibexa\Contracts\CorePersistence\Exception\RuntimeMappingExceptionInterface
+     */
     public function getColumn(string $column): string;
 
     public function getInheritanceMetadataWithColumn(string $column): ?self;
@@ -70,6 +76,8 @@ interface DoctrineSchemaMetadataInterface
      * @param array<string, mixed> $data
      *
      * @return array<string, mixed>
+     *
+     * @throws \Ibexa\Contracts\CorePersistence\Exception\RuntimeMappingExceptionInterface
      */
     public function convertToDatabaseValues(array $data): array;
 
@@ -77,6 +85,8 @@ interface DoctrineSchemaMetadataInterface
      * @param array<string, mixed> $data
      *
      * @return array<string, int>
+     *
+     * @throws \Ibexa\Contracts\CorePersistence\Exception\RuntimeMappingExceptionInterface
      */
     public function getBindingTypesForData(array $data): array;
 
@@ -87,9 +97,13 @@ interface DoctrineSchemaMetadataInterface
 
     /**
      * @throws \Doctrine\DBAL\Exception
+     * @throws \Ibexa\Contracts\CorePersistence\Exception\RuntimeMappingExceptionInterface
      */
     public function getBindingTypeForColumn(string $columnName): int;
 
+    /**
+     * @throws \Ibexa\Contracts\CorePersistence\Exception\MappingExceptionInterface
+     */
     public function setParentMetadata(self $parentMetadata): void;
 
     public function getParentMetadata(): ?self;
@@ -101,18 +115,30 @@ interface DoctrineSchemaMetadataInterface
      */
     public function getSubclasses(): array;
 
+    /**
+     * @throws \Ibexa\Contracts\CorePersistence\Exception\MappingExceptionInterface
+     */
     public function addSubclass(string $discriminator, self $doctrineSchemaMetadata): void;
 
     public function isInheritanceTypeJoined(): bool;
 
+    /**
+     * @throws \Ibexa\Contracts\CorePersistence\Exception\MappingExceptionInterface
+     */
     public function setTranslationSchemaMetadata(TranslationDoctrineSchemaMetadataInterface $translationMetadata): void;
 
     public function hasTranslationSchemaMetadata(): bool;
 
+    /**
+     * @throws \Ibexa\Contracts\CorePersistence\Exception\RuntimeMappingExceptionInterface
+     */
     public function getTranslationSchemaMetadata(): TranslationDoctrineSchemaMetadataInterface;
 
     public function isTranslatedColumn(string $column): bool;
 
+    /**
+     * @throws \Ibexa\Contracts\CorePersistence\Exception\MappingExceptionInterface
+     */
     public function addRelationship(DoctrineRelationshipInterface $relationship): void;
 
     /**
@@ -120,7 +146,13 @@ interface DoctrineSchemaMetadataInterface
      */
     public function getRelationships(): array;
 
+    /**
+     * @throws \Ibexa\Contracts\CorePersistence\Exception\RuntimeMappingExceptionInterface
+     */
     public function getRelationshipByForeignProperty(string $foreignProperty): DoctrineRelationshipInterface;
 
+    /**
+     * @throws \Ibexa\Contracts\CorePersistence\Exception\RuntimeMappingExceptionInterface
+     */
     public function getRelationshipByForeignColumn(string $foreignColumn): DoctrineRelationshipInterface;
 }

--- a/src/contracts/Gateway/DoctrineSchemaMetadataInterface.php
+++ b/src/contracts/Gateway/DoctrineSchemaMetadataInterface.php
@@ -120,5 +120,7 @@ interface DoctrineSchemaMetadataInterface
      */
     public function getRelationships(): array;
 
-    public function getRelationshipByForeignKeyColumn(string $foreignProperty): DoctrineRelationshipInterface;
+    public function getRelationshipByForeignProperty(string $foreignProperty): DoctrineRelationshipInterface;
+
+    public function getRelationshipByForeignColumn(string $foreignColumn): DoctrineRelationshipInterface;
 }

--- a/src/lib/Gateway/ExpressionVisitor.php
+++ b/src/lib/Gateway/ExpressionVisitor.php
@@ -19,6 +19,7 @@ use Ibexa\Contracts\CorePersistence\Gateway\DoctrineOneToManyRelationship;
 use Ibexa\Contracts\CorePersistence\Gateway\DoctrineRelationship;
 use Ibexa\Contracts\CorePersistence\Gateway\DoctrineSchemaMetadataInterface;
 use Ibexa\Contracts\CorePersistence\Gateway\DoctrineSchemaMetadataRegistryInterface;
+use InvalidArgumentException;
 use RuntimeException;
 
 /**
@@ -79,10 +80,10 @@ final class ExpressionVisitor extends BaseExpressionVisitor
                 $foreignClassProperty,
             ] = explode('.', $column, 2);
 
-            $relationship = $this->schemaMetadata->getRelationshipByForeignKeyColumn($foreignProperty);
+            $relationship = $this->schemaMetadata->getRelationshipByForeignProperty($foreignProperty);
             $relationshipMetadata = $this->registry->getMetadata($relationship->getRelationshipClass());
             if (!$relationshipMetadata->hasColumn($foreignClassProperty)) {
-                throw new \InvalidArgumentException(sprintf(
+                throw new InvalidArgumentException(sprintf(
                     '"%s" does not exist as available column on "%s" class schema metadata. Available columns: "%s".',
                     $foreignClassProperty,
                     $relationshipMetadata->getClassName(),

--- a/src/lib/Gateway/ExpressionVisitor.php
+++ b/src/lib/Gateway/ExpressionVisitor.php
@@ -20,7 +20,6 @@ use Ibexa\Contracts\CorePersistence\Gateway\DoctrineOneToManyRelationship;
 use Ibexa\Contracts\CorePersistence\Gateway\DoctrineRelationship;
 use Ibexa\Contracts\CorePersistence\Gateway\DoctrineSchemaMetadataInterface;
 use Ibexa\Contracts\CorePersistence\Gateway\DoctrineSchemaMetadataRegistryInterface;
-use InvalidArgumentException;
 use RuntimeException;
 
 /**

--- a/tests/bundle/Gateway/DoctrineSchemaMetadataTest.php
+++ b/tests/bundle/Gateway/DoctrineSchemaMetadataTest.php
@@ -34,7 +34,7 @@ final class DoctrineSchemaMetadataTest extends TestCase
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('"foo" does not exist as a relationship for "stdClass" class metadata. Available relationship columns: ""');
-        $this->metadata->getRelationshipByForeignColumn('foo');
+        $this->metadata->getRelationshipByForeignKeyColumn('foo');
     }
 
     public function testGetRelationshipByForeignPropertyWithoutRelationships(): void
@@ -49,7 +49,7 @@ final class DoctrineSchemaMetadataTest extends TestCase
         $relationship = $this->getFooRelationship();
         $this->metadata->addRelationship($relationship);
 
-        $result = $this->metadata->getRelationshipByForeignColumn('foo_column');
+        $result = $this->metadata->getRelationshipByForeignKeyColumn('foo_column');
         self::assertSame($relationship, $result);
     }
 

--- a/tests/bundle/Gateway/DoctrineSchemaMetadataTest.php
+++ b/tests/bundle/Gateway/DoctrineSchemaMetadataTest.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Ibexa\Tests\Bundle\CorePersistence\Gateway;
 
+use Ibexa\Contracts\CorePersistence\Exception\RuntimeMappingExceptionInterface;
 use Ibexa\Contracts\CorePersistence\Gateway\DoctrineRelationshipInterface;
 use Ibexa\Contracts\CorePersistence\Gateway\DoctrineSchemaMetadata;
 use PHPUnit\Framework\TestCase;
@@ -32,14 +33,14 @@ final class DoctrineSchemaMetadataTest extends TestCase
 
     public function testGetRelationshipByForeignColumnWithoutRelationships(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(RuntimeMappingExceptionInterface::class);
         $this->expectExceptionMessage('"foo" does not exist as a relationship for "stdClass" class metadata. Available relationship columns: ""');
         $this->metadata->getRelationshipByForeignKeyColumn('foo');
     }
 
     public function testGetRelationshipByForeignPropertyWithoutRelationships(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(RuntimeMappingExceptionInterface::class);
         $this->expectExceptionMessage('"foo" does not exist as a relationship for "stdClass" class metadata. Available relationship property: ""');
         $this->metadata->getRelationshipByForeignProperty('foo');
     }

--- a/tests/bundle/Gateway/DoctrineSchemaMetadataTest.php
+++ b/tests/bundle/Gateway/DoctrineSchemaMetadataTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Bundle\CorePersistence\Gateway;
+
+use Ibexa\Contracts\CorePersistence\Gateway\DoctrineRelationshipInterface;
+use Ibexa\Contracts\CorePersistence\Gateway\DoctrineSchemaMetadata;
+use PHPUnit\Framework\TestCase;
+
+final class DoctrineSchemaMetadataTest extends TestCase
+{
+    private DoctrineSchemaMetadata $metadata;
+
+    protected function setUp(): void
+    {
+        $this->metadata = new DoctrineSchemaMetadata(
+            $this->createMock(\Doctrine\DBAL\Connection::class),
+            'stdClass',
+            'std_class_table',
+            [
+                'id' => 'integer',
+                'column_string' => 'string',
+            ],
+            ['id'],
+        );
+    }
+
+    public function testGetRelationshipByForeignColumnWithoutRelationships(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('"foo" does not exist as a relationship for "stdClass" class metadata. Available relationship columns: ""');
+        $this->metadata->getRelationshipByForeignColumn('foo');
+    }
+
+    public function testGetRelationshipByForeignPropertyWithoutRelationships(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('"foo" does not exist as a relationship for "stdClass" class metadata. Available relationship property: ""');
+        $this->metadata->getRelationshipByForeignProperty('foo');
+    }
+
+    public function testGetRelationshipByForeignColumn(): void
+    {
+        $relationship = $this->getFooRelationship();
+        $this->metadata->addRelationship($relationship);
+
+        $result = $this->metadata->getRelationshipByForeignColumn('foo_column');
+        self::assertSame($relationship, $result);
+    }
+
+    public function testGetRelationshipByForeignProperty(): void
+    {
+        $relationship = $this->getFooRelationship();
+        $this->metadata->addRelationship($relationship);
+
+        $result = $this->metadata->getRelationshipByForeignProperty('foo_property');
+        self::assertSame($relationship, $result);
+    }
+
+    private function getFooRelationship(): DoctrineRelationshipInterface
+    {
+        $relationship = $this->createMock(DoctrineRelationshipInterface::class);
+        $relationship->method('getForeignKeyColumn')->willReturn('foo_column');
+        $relationship->method('getForeignProperty')->willReturn('foo_property');
+
+        return $relationship;
+    }
+}

--- a/tests/bundle/Gateway/ExpressionVisitorTest.php
+++ b/tests/bundle/Gateway/ExpressionVisitorTest.php
@@ -14,6 +14,11 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Query\Expression\ExpressionBuilder;
 use Doctrine\DBAL\Query\QueryBuilder;
+use Ibexa\Contracts\CorePersistence\Exception\RuntimeMappingExceptionInterface;
+use Ibexa\Contracts\CorePersistence\Gateway\DoctrineOneToManyRelationship;
+use Ibexa\Contracts\CorePersistence\Gateway\DoctrineRelationship;
+use Ibexa\Contracts\CorePersistence\Gateway\DoctrineRelationshipInterface;
+use Ibexa\Contracts\CorePersistence\Gateway\DoctrineSchemaMetadataInterface;
 use Ibexa\Contracts\CorePersistence\Gateway\DoctrineSchemaMetadataRegistryInterface;
 use Ibexa\CorePersistence\Gateway\ExpressionVisitor;
 use Ibexa\CorePersistence\Gateway\Parameter;
@@ -23,22 +28,41 @@ final class ExpressionVisitorTest extends TestCase
 {
     private ExpressionVisitor $expressionVisitor;
 
+    /** @var \Ibexa\Contracts\CorePersistence\Gateway\DoctrineSchemaMetadataRegistryInterface&\PHPUnit\Framework\MockObject\MockObject */
+    private DoctrineSchemaMetadataRegistryInterface $registry;
+
+    /** @var \Ibexa\Contracts\CorePersistence\Gateway\DoctrineSchemaMetadataInterface&\PHPUnit\Framework\MockObject\MockObject */
+    private DoctrineSchemaMetadataInterface $schemaMetadata;
+
+    private QueryBuilder $queryBuilder;
+
+    /** @var \Doctrine\DBAL\Connection&\PHPUnit\Framework\MockObject\MockObject */
+    private Connection $connection;
+
     protected function setUp(): void
     {
-        $connection = $this->createMock(Connection::class);
+        $this->connection = $this->createMock(Connection::class);
 
-        $connection->method('getExpressionBuilder')
-            ->willReturn(new ExpressionBuilder($connection));
+        $this->connection->method('getExpressionBuilder')
+            ->willReturn(new ExpressionBuilder($this->connection));
 
         $platform = $this->getMockBuilder(AbstractPlatform::class)
             ->getMockForAbstractClass();
 
-        $connection->method('getDatabasePlatform')
+        $this->connection->method('getDatabasePlatform')
             ->willReturn($platform);
 
+        $this->schemaMetadata = $this->createMock(DoctrineSchemaMetadataInterface::class);
+
+        $this->registry = $this->createMock(DoctrineSchemaMetadataRegistryInterface::class);
+        $this->registry->method('getMetadataForTable')
+            ->with('table_name')
+            ->willReturn($this->schemaMetadata);
+
+        $this->queryBuilder = new QueryBuilder($this->connection);
         $this->expressionVisitor = new ExpressionVisitor(
-            new QueryBuilder($connection),
-            $this->createMock(DoctrineSchemaMetadataRegistryInterface::class),
+            $this->queryBuilder,
+            $this->registry,
             'table_name',
             'table_alias',
         );
@@ -46,6 +70,8 @@ final class ExpressionVisitorTest extends TestCase
 
     public function testWalkComparison(): void
     {
+        $this->configureFieldInMetadata($this->schemaMetadata, ['field']);
+
         $result = $this->expressionVisitor->dispatch(new Comparison('field', '=', 'value'));
 
         self::assertSame('table_alias.field = :field_0', $result);
@@ -60,6 +86,8 @@ final class ExpressionVisitorTest extends TestCase
 
     public function testLogicalNot(): void
     {
+        $this->configureFieldInMetadata($this->schemaMetadata, ['field']);
+
         $result = $this->expressionVisitor->dispatch(
             new CompositeExpression('NOT', [new Comparison('field', '=', 'value')]),
         );
@@ -76,6 +104,8 @@ final class ExpressionVisitorTest extends TestCase
 
     public function testLogicalAnd(): void
     {
+        $this->configureFieldInMetadata($this->schemaMetadata, ['field', 'field_2']);
+
         $result = $this->expressionVisitor->dispatch(
             new CompositeExpression('AND', [
                 new Comparison('field', '=', 'value'),
@@ -100,5 +130,160 @@ final class ExpressionVisitorTest extends TestCase
                 0,
             ),
         ], $this->expressionVisitor->getParameters());
+    }
+
+    public function testFieldNotFound(): void
+    {
+        $this->expectException(RuntimeMappingExceptionInterface::class);
+        $this->expressionVisitor->dispatch(new Comparison('field', '=', 'value'));
+    }
+
+    public function testFieldFromMissingRelationship(): void
+    {
+        /** @var \Exception $exception */
+        $exception = $this->createMock(RuntimeMappingExceptionInterface::class);
+        $this->schemaMetadata
+            ->expects(self::once())
+            ->method('getRelationshipByForeignProperty')
+            ->with('relationship_1')
+            ->willThrowException($exception);
+
+        $this->expectExceptionObject($exception);
+        $this->expressionVisitor->dispatch(new Comparison('relationship_1.field', '=', 'value'));
+    }
+
+    public function testFieldUnknownRelationshipType(): void
+    {
+        /** @var class-string $relationshipClass pretend it's a class-string */
+        $relationshipClass = 'relationship_class';
+
+        $doctrineRelationship = $this->createMock(DoctrineRelationshipInterface::class);
+        $doctrineRelationship->method('getRelationshipClass')->willReturn($relationshipClass);
+        $this->schemaMetadata
+            ->expects(self::once())
+            ->method('getRelationshipByForeignProperty')
+            ->with('relationship_1')
+            ->willReturn($doctrineRelationship);
+
+        $relationshipMetadata = $this->createRelationshipSchemaMetadata();
+
+        $this->registry
+            ->expects(self::once())
+            ->method('getMetadata')
+            ->with(self::identicalTo($relationshipClass))
+            ->willReturn($relationshipMetadata);
+
+        $this->expectException(RuntimeMappingExceptionInterface::class);
+        $this->expectExceptionMessage(
+            'Unhandled relationship metadata. Expected one of '
+            . '"Ibexa\Contracts\CorePersistence\Gateway\DoctrineRelationship", '
+            . '"Ibexa\Contracts\CorePersistence\Gateway\DoctrineOneToManyRelationship". '
+            . 'Received "' . get_class($doctrineRelationship) . '"'
+        );
+        $this->expressionVisitor->dispatch(new Comparison('relationship_1.field', '=', 'value'));
+    }
+
+    public function testFieldFromSubSelectRelationship(): void
+    {
+        $this->connection
+            ->expects(self::once())
+            ->method('createQueryBuilder')
+            ->willReturnCallback(fn () => new QueryBuilder($this->connection));
+
+        /** @var class-string $relationshipClass pretend it's a class-string */
+        $relationshipClass = 'relationship_class';
+        $doctrineRelationship = new DoctrineRelationship(
+            $relationshipClass,
+            'relationship_1',
+            'relationship_id',
+            'id',
+        );
+
+        $this->schemaMetadata
+            ->expects(self::once())
+            ->method('getRelationshipByForeignProperty')
+            ->with('relationship_1')
+            ->willReturn($doctrineRelationship);
+
+        $relationshipMetadata = $this->createRelationshipSchemaMetadata();
+
+        $this->registry
+            ->expects(self::once())
+            ->method('getMetadata')
+            ->with($relationshipClass)
+            ->willReturn($relationshipMetadata);
+
+        $result = $this->expressionVisitor->dispatch(new Comparison('relationship_1.field', '=', 'value'));
+        self::assertSame(
+            'table_alias.relationship_id IN (SELECT relationship_table_name.id FROM relationship_table_name '
+            . 'WHERE relationship_table_name.field IN (:field_0))',
+            $result,
+        );
+    }
+
+    public function testFieldFromInheritedRelationship(): void
+    {
+        /** @var class-string $relationshipClass pretend it's a class-string */
+        $relationshipClass = 'relationship_class';
+        $doctrineRelationship = new DoctrineOneToManyRelationship(
+            $relationshipClass,
+            'relationship_1',
+            'relationship_id',
+        );
+
+        $this->schemaMetadata
+            ->expects(self::once())
+            ->method('getRelationshipByForeignProperty')
+            ->with('relationship_1')
+            ->willReturn($doctrineRelationship);
+
+        $relationshipMetadata = $this->createRelationshipSchemaMetadata();
+
+        $this->registry
+            ->expects(self::once())
+            ->method('getMetadata')
+            ->with($relationshipClass)
+            ->willReturn($relationshipMetadata);
+
+        $result = $this->expressionVisitor->dispatch(new Comparison('relationship_1.field', '=', 'value'));
+        self::assertSame(
+            'relationship_table_name.field = :field_0',
+            $result,
+        );
+    }
+
+    private function createRelationshipSchemaMetadata(): DoctrineSchemaMetadataInterface
+    {
+        $relationshipMetadata = $this->createMock(DoctrineSchemaMetadataInterface::class);
+        $relationshipMetadata
+            ->method('hasColumn')
+            ->with('field')
+            ->willReturn(true);
+
+        $relationshipMetadata
+            ->method('getTableName')
+            ->willReturn('relationship_table_name');
+
+        $relationshipMetadata
+            ->method('getIdentifierColumn')
+            ->willReturn('id');
+
+        return $relationshipMetadata;
+    }
+
+    /**
+     * @param \Ibexa\Contracts\CorePersistence\Gateway\DoctrineSchemaMetadataInterface&\PHPUnit\Framework\MockObject\MockObject $metadata
+     * @param array<string> $fields
+     */
+    private function configureFieldInMetadata(DoctrineSchemaMetadataInterface $metadata, array $fields): void
+    {
+        $fields = array_map('preg_quote', $fields);
+        $regexp = sprintf('~^(%s)$~', implode('|', $fields));
+
+        $metadata
+            ->expects(self::atLeastOnce())
+            ->method('hasColumn')
+            ->with(self::matchesRegularExpression($regexp))
+            ->willReturn(true);
     }
 }


### PR DESCRIPTION
| Question                 | Answer                                              |
|--------------------------|-----------------------------------------------------|
| **JIRA issue**           | [IBX-6824](https://issues.ibexa.co/browse/IBX-6824) |
| **Type**                 | bug                             |
| **Target Ibexa version** | `v4.6`
| **BC breaks**            | no                                              |

Despite the name
```php
public function getRelationshipByForeignColumn(string $foreignProperty): DoctrineRelationshipInterface;
```
method was working with foreign key column in it's actual implementation. This PR remedies that, making the method properly return based on foreign column.

Additionally:
 * a proper
```php
public function getRelationshipByForeignProperty(string $foreignProperty): DoctrineRelationshipInterface;
```
is introduced.
 * `MappingExceptionInterface` and `RuntimeMappingExceptionInterface` are introduced. The former is responsible for any errors that happen when schema metadata is declared (column collisions primarily). The latter can be thrown if non-existent columns are being accessed and similar.
 * Relation-related tests are added to `ExpressionVisitor`

#### Checklist:

- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping for example `@ibexa/php-dev` for back-end changes and/or `@ibexa/javascript-dev` for
  front-end changes).
