### PR TITLE
IBX-6824: Skip column to foreign relationship mapping for primary key

### DIFF
--- a/src/contracts/Gateway/DoctrineSchemaMetadata.php
+++ b/src/contracts/Gateway/DoctrineSchemaMetadata.php
@@ -371,6 +371,10 @@ class DoctrineSchemaMetadata implements DoctrineSchemaMetadataInterface
         $this->propertyToRelationship[$foreignProperty] = $relationship;
 
         $foreignColumn = $relationship->getForeignKeyColumn();
+        if ($foreignColumn === $this->getIdentifierColumn()) {
+            return;
+        }
+
         if (isset($this->columnToRelationship[$foreignColumn])) {
             throw new MappingException(sprintf(
                 '"%s" is already added as foreign column.',


### PR DESCRIPTION
| Question                 | Answer                                              |
|--------------------------|-----------------------------------------------------|
| **JIRA issue**           | [IBX-6824](https://issues.ibexa.co/browse/IBX-6824) |
| **Type**                 | bug
| **Target Ibexa version** | `v4.6`

This PR fixes an issue introduced in #7. In case of tables that share primary key (inherited ones) the same table acts as a foreign key for multiple tables.

Without this fix current application will crash:
```
Executing migration "010_currencies.yml" failed. Exception: "id" is already added as foreign
  column..


In DoctrineSchemaMetadata.php line 375:

  "id" is already added as foreign column.
```

#### Checklist:

- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping for example `@ibexa/php-dev` for back-end changes and/or `@ibexa/javascript-dev` for
  front-end changes).
