### PR TITLE
IBX-6824: Fixed inheritance column reported as invalid

### DIFF
--- a/src/lib/Gateway/ExpressionVisitor.php
+++ b/src/lib/Gateway/ExpressionVisitor.php
@@ -123,7 +123,7 @@ final class ExpressionVisitor extends BaseExpressionVisitor
             return $this->handleTranslation($comparison);
         }
 
-        if (!$this->schemaMetadata->hasColumn($column)) {
+        if (!$this->schemaMetadata->hasColumn($column) && !$this->schemaMetadata->isInheritedColumn($column)) {
             throw new RuntimeMappingException(sprintf(
                 '%s table metadata does not contain %s column.',
                 $this->schemaMetadata->getTableName(),

--- a/tests/bundle/Gateway/ExpressionVisitorTest.php
+++ b/tests/bundle/Gateway/ExpressionVisitorTest.php
@@ -31,7 +31,7 @@ final class ExpressionVisitorTest extends TestCase
     /** @var \Ibexa\Contracts\CorePersistence\Gateway\DoctrineSchemaMetadataRegistryInterface&\PHPUnit\Framework\MockObject\MockObject */
     private DoctrineSchemaMetadataRegistryInterface $registry;
 
-    /** @var DoctrineSchemaMetadataInterface&\PHPUnit\Framework\MockObject\MockObject */
+    /** @var \Ibexa\Contracts\CorePersistence\Gateway\DoctrineSchemaMetadataInterface&\PHPUnit\Framework\MockObject\MockObject */
     private DoctrineSchemaMetadataInterface $schemaMetadata;
 
     private QueryBuilder $queryBuilder;
@@ -299,7 +299,7 @@ final class ExpressionVisitorTest extends TestCase
     }
 
     /**
-     * @param DoctrineSchemaMetadataInterface&\PHPUnit\Framework\MockObject\MockObject $metadata
+     * @param \Ibexa\Contracts\CorePersistence\Gateway\DoctrineSchemaMetadataInterface&\PHPUnit\Framework\MockObject\MockObject $metadata
      * @param array<string> $fields
      */
     private function configureFieldInMetadata(DoctrineSchemaMetadataInterface $metadata, array $fields): void


### PR DESCRIPTION
| Question                 | Answer                                              |
|--------------------------|-----------------------------------------------------|
| **JIRA issue**           | [IBX-6824](https://issues.ibexa.co/browse/IBX-6824) |
| **Type**                 | bug
| **Target Ibexa version** | `v4.6`
| **BC breaks**            | no

Fixes an issue introduced in #7, there inheritance-related columns were reported as non-existent.

#### Checklist:

- [x] Provided PR description.
- [ ] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping for example `@ibexa/php-dev` for back-end changes and/or `@ibexa/javascript-dev` for
  front-end changes).
