### PR TITLE
IBX-6634: Fixed relationship comparison

### DIFF
--- a/src/contracts/Gateway/AbstractDoctrineDatabase.php
+++ b/src/contracts/Gateway/AbstractDoctrineDatabase.php
@@ -131,7 +131,7 @@ abstract class AbstractDoctrineDatabase implements GatewayInterface
         $identifierColumn = $metadata->getIdentifierColumn();
         $tableAlias = $this->getTableAlias();
         $platform = $this->connection->getDatabasePlatform();
-        $qb->select($platform->getCountExpression($tableAlias . '.' . $identifierColumn));
+        $qb->select($platform->getCountExpression(sprintf('DISTINCT %s.%s', $tableAlias, $identifierColumn)));
 
         $this->applyCriteria($qb, $criteria);
 

--- a/src/contracts/Gateway/AbstractDoctrineDatabase.php
+++ b/src/contracts/Gateway/AbstractDoctrineDatabase.php
@@ -126,13 +126,13 @@ abstract class AbstractDoctrineDatabase implements GatewayInterface
     {
         $metadata = $this->getMetadata();
         $qb = $this->createBaseQueryBuilder();
+        $this->applyInheritance($qb);
 
         $identifierColumn = $metadata->getIdentifierColumn();
         $tableAlias = $this->getTableAlias();
         $platform = $this->connection->getDatabasePlatform();
         $qb->select($platform->getCountExpression($tableAlias . '.' . $identifierColumn));
 
-        $this->applyInheritance($qb);
         $this->applyCriteria($qb, $criteria);
 
         return (int)$qb->execute()->fetchOne();

--- a/src/contracts/Gateway/AbstractDoctrineDatabase.php
+++ b/src/contracts/Gateway/AbstractDoctrineDatabase.php
@@ -125,18 +125,15 @@ abstract class AbstractDoctrineDatabase implements GatewayInterface
     public function countBy($criteria): int
     {
         $metadata = $this->getMetadata();
-        $qb = $this->connection->createQueryBuilder();
-        $this->applyInheritance($qb);
+        $qb = $this->createBaseQueryBuilder();
 
         $identifierColumn = $metadata->getIdentifierColumn();
         $tableAlias = $this->getTableAlias();
-        $qb->select($this->connection->getDatabasePlatform()->getCountExpression($tableAlias . '.' . $identifierColumn));
-        $qb->from($metadata->getTableName(), $tableAlias);
+        $platform = $this->connection->getDatabasePlatform();
+        $qb->select($platform->getCountExpression($tableAlias . '.' . $identifierColumn));
 
-        $expr = $this->convertCriteriaToExpression($qb, $criteria);
-        if ($expr !== null) {
-            $qb->andWhere($expr);
-        }
+        $this->applyInheritance($qb);
+        $this->applyCriteria($qb, $criteria);
 
         return (int)$qb->execute()->fetchOne();
     }
@@ -162,39 +159,10 @@ abstract class AbstractDoctrineDatabase implements GatewayInterface
         $qb = $this->createBaseQueryBuilder();
         $this->applyInheritance($qb);
 
-        foreach ($orderBy ?? [] as $column => $order) {
-            if (!$metadata->hasColumn($column) && !$metadata->isInheritedColumn($column)) {
-                $columns = $metadata->getColumns();
-                foreach ($metadata->getSubclasses() as $subMetadata) {
-                    $columns = array_merge($columns, $subMetadata->getColumns());
-                }
+        $this->applyOrderBy($qb, $orderBy);
+        $this->applyCriteria($qb, $criteria);
+        $this->applyLimits($qb, $limit, $offset);
 
-                throw new InvalidArgumentException(sprintf(
-                    '"%s" does not exist in "%s", or is not available for ordering. Available columns are: "%s"',
-                    $column,
-                    $this->getTableName(),
-                    implode('", "', $columns),
-                ));
-            }
-
-            if ($metadata->isInheritedColumn($column)) {
-                $subMetadata = $metadata->getInheritanceMetadataWithColumn($column);
-                assert($subMetadata !== null);
-                $qb->addOrderBy($subMetadata->getTableName() . '.' . $column, $order);
-            } else {
-                $qb->addOrderBy($this->getTableAlias() . '.' . $column, $order);
-            }
-        }
-
-        $expr = $this->convertCriteriaToExpression($qb, $criteria);
-        if ($expr !== null) {
-            $qb->andWhere($expr);
-        }
-
-        if ($limit !== null) {
-            $qb->setMaxResults($limit);
-        }
-        $qb->setFirstResult($offset);
         $results = $qb->execute()->fetchAllAssociative();
 
         return array_map([$metadata, 'convertToPHPValues'], $results);
@@ -426,5 +394,56 @@ abstract class AbstractDoctrineDatabase implements GatewayInterface
         $parameter = $qb->createPositionalParameter($value, $columnBinding);
 
         return $qb->expr()->eq($fullColumnName, $parameter);
+    }
+
+    /**
+     * @param array<string, string>|null $orderBy Map of column names to "ASC" or "DESC", that will be used in SORT query
+     */
+    final protected function applyOrderBy(QueryBuilder $qb, ?array $orderBy = []): void
+    {
+        $metadata = $this->getMetadata();
+
+        foreach ($orderBy ?? [] as $column => $order) {
+            if (!$metadata->hasColumn($column) && !$metadata->isInheritedColumn($column)) {
+                $columns = $metadata->getColumns();
+                foreach ($metadata->getSubclasses() as $subMetadata) {
+                    $columns = array_merge($columns, $subMetadata->getColumns());
+                }
+
+                throw new InvalidArgumentException(sprintf(
+                    '"%s" does not exist in "%s", or is not available for ordering. Available columns are: "%s"',
+                    $column,
+                    $this->getTableName(),
+                    implode('", "', $columns),
+                ));
+            }
+
+            if ($metadata->isInheritedColumn($column)) {
+                $subMetadata = $metadata->getInheritanceMetadataWithColumn($column);
+                assert($subMetadata !== null);
+                $qb->addOrderBy($subMetadata->getTableName() . '.' . $column, $order);
+            } else {
+                $qb->addOrderBy($this->getTableAlias() . '.' . $column, $order);
+            }
+        }
+    }
+
+    /**
+     * @param \Doctrine\Common\Collections\Expr\Expression|array<string, \Doctrine\Common\Collections\Expr\Expression|scalar|array<scalar>|null> $criteria
+     */
+    final protected function applyCriteria(QueryBuilder $qb, $criteria): void
+    {
+        $expr = $this->convertCriteriaToExpression($qb, $criteria);
+        if ($expr !== null) {
+            $qb->andWhere($expr);
+        }
+    }
+
+    final protected function applyLimits(QueryBuilder $qb, ?int $limit, int $offset): void
+    {
+        if ($limit !== null) {
+            $qb->setMaxResults($limit);
+        }
+        $qb->setFirstResult($offset);
     }
 }


### PR DESCRIPTION
| Question                 | Answer                                              |
|--------------------------|-----------------------------------------------------|
| **JIRA issue**           | [IBX-6634](https://issues.ibexa.co/browse/IBX-6634) |
| **Type**                 | bug                             |
| **Target Ibexa version** | `v4.6`              |
| **BC breaks**            | no                                              |

This PR fixes issues that occur when a Criterion is used that represents a relationship condition.

For example, `LoggedAt` criterion which involved sub-tables with "lower than" condition was overwritten with a "equal to", because comparison operator was ignored - only value was used.

Additionally, a few methods are exposed for use in descendants so that common operations when building a query can be performed without repetition.

_EDIT: Additionally, this also apparently fixes an issue that happens when attempting to `countBy` items, while using sub-tables (pre-joined tables are missing)._

#### Checklist:

- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping for example `@ibexa/php-dev` for back-end changes and/or `@ibexa/javascript-dev` for
  front-end changes).
