### PR TITLE
IBX-7355: Allowed LIKE query conditions in Criteria for joins

### DIFF
--- a/src/lib/Gateway/ExpressionVisitor.php
+++ b/src/lib/Gateway/ExpressionVisitor.php
@@ -323,8 +323,12 @@ final class ExpressionVisitor extends BaseExpressionVisitor
             && $this->schemaMetadata->isInheritedColumn($column);
     }
 
-    private function handleComparison(Comparison $comparison, Parameter $parameter, string $fullColumnName, string $placeholder): string
-    {
+    private function handleComparison(
+        Comparison $comparison,
+        Parameter $parameter,
+        string $fullColumnName,
+        string $placeholder
+    ): string {
         switch ($comparison->getOperator()) {
             case Comparison::IN:
                 $this->parameters[] = $parameter;

--- a/tests/integration/Gateway/ExpressionVisitorTest.php
+++ b/tests/integration/Gateway/ExpressionVisitorTest.php
@@ -69,7 +69,7 @@ final class ExpressionVisitorTest extends IbexaKernelTestCase
                 'IN',
                 'bar',
             ),
-            'relationship_2_table_name.relationship_2_foo IN :relationship_2_foo_0',
+            'relationship_2_table_name.relationship_2_foo IN (:relationship_2_foo_0)',
         ];
 
         yield [


### PR DESCRIPTION
| Question                 | Answer                                              |
|--------------------------|-----------------------------------------------------|
| **JIRA issue**           | [IBX-7355](https://issues.ibexa.co/browse/IBX-7355) |
| **Type**                 | feature                             |
| **Target Ibexa version** | `v4.6`

This PR allows query conditions, specifically those related to JOINed tables, to make use of `CONTAINS` / `STARTS_WITH` / `ENDS_WITH` operators, which correspond to `LIKE` conditions.

#### Checklist:

- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping for example `@ibexa/php-dev` for back-end changes and/or `@ibexa/javascript-dev` for
  front-end changes).
