### PR TITLE
Update composer.json remove extra symfony/event-dispatcher-contracts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,6 @@
     "symfony/config": "^5.4",
     "symfony/dependency-injection": "^5.4",
     "symfony/event-dispatcher": "^5.4",
-    "symfony/event-dispatcher-contracts": "^2.2",
     "symfony/http-foundation": "^5.4",
     "symfony/http-kernel": "^5.4",
     "symfony/yaml": "^5.4"


### PR DESCRIPTION
remove extra symfony/event-dispatcher-contracts as symfony/event-dispatcher already sets the requirement

Adding this makes only the lower version allowed instead of also allowing ^3

| Question                 | Answer                                              |
|--------------------------|-----------------------------------------------------|
| **JIRA issue**           | [IBX-7782](https://issues.ibexa.co/browse/IBX-7782) |
| **Type**                 | bug                            |
| **Target Ibexa version** | `v4.6`           |
| **BC breaks**            | yes                                         |

composer.json templates added that specify

"symfony/event-dispatcher": "^5.4",
"symfony/event-dispatcher-contracts": "^2.2",

This creates conflict if using another bundle that uses "symfony/event-dispatcher-contracts": "^3"

The symfony/event-dispatcher itself restricts "symfony/event-dispatcher-contracts": "^2 || ^3" allowing version 3+

The limitation of ^2.2 looks arbitrary and should be removed as symfony/event-dispatcher already defines the allowed version.

Also for a repo like ibexa/core-persistence, the dispatcher isn't even used.

#### Checklist:

- [x] Provided PR description.
- [ ] Tested the solution manually.
- [ ] Provided automated test coverage.
- [ ] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [ ] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review (ping for example `@ibexa/php-dev` for back-end changes and/or `@ibexa/javascript-dev` for
  front-end changes).
