### PR TITLE
IBX-8119: Upgraded minimum PHP version to 8.3

### DIFF
--- a/.github/workflows/backend-ci.yaml
+++ b/.github/workflows/backend-ci.yaml
@@ -14,9 +14,9 @@ jobs:
         strategy:
             matrix:
                 php:
-                    - '8.1'
+                    - '8.3'
         steps:
-            -   uses: actions/checkout@v3
+            -   uses: actions/checkout@v4
 
             -   name: Setup PHP Action
                 uses: shivammathur/setup-php@v2
@@ -26,7 +26,7 @@ jobs:
                     extensions: 'pdo_sqlite, gd'
                     tools: cs2pr
 
-            -   uses: ramsey/composer-install@v2
+            -   uses: ramsey/composer-install@v3
                 with:
                     dependency-versions: highest
 
@@ -42,12 +42,10 @@ jobs:
             fail-fast: false
             matrix:
                 php:
-                    - '7.4'
-                    - '8.1'
-                    - '8.2'
+                    - '8.3'
 
         steps:
-            -   uses: actions/checkout@v3
+            -   uses: actions/checkout@v4
 
             -   name: Setup PHP Action
                 uses: shivammathur/setup-php@v2
@@ -56,7 +54,7 @@ jobs:
                     coverage: none
                     extensions: pdo_sqlite, gd
 
-            -   uses: ramsey/composer-install@v2
+            -   uses: ramsey/composer-install@v3
                 with:
                     dependency-versions: highest
 
@@ -92,12 +90,10 @@ jobs:
         strategy:
             matrix:
                 php:
-                    - '7.4'
-                    - '8.0'
-                    - '8.2'
+                    - '8.3'
 
         steps:
-            -   uses: actions/checkout@v3
+            -   uses: actions/checkout@v4
 
             -   name: Setup PHP Action
                 uses: shivammathur/setup-php@v2
@@ -107,7 +103,7 @@ jobs:
                     extensions: pdo_pgsql, gd
                     tools: cs2pr
 
-            -   uses: ramsey/composer-install@v2
+            -   uses: ramsey/composer-install@v3
                 with:
                     dependency-versions: highest
 
@@ -145,12 +141,10 @@ jobs:
         strategy:
             matrix:
                 php:
-                    - '7.4'
-                    - '8.0'
-                    - '8.2'
+                    - '8.3'
 
         steps:
-            -   uses: actions/checkout@v3
+            -   uses: actions/checkout@v4
 
             -   name: Setup PHP Action
                 uses: shivammathur/setup-php@v2
@@ -160,7 +154,7 @@ jobs:
                     extensions: pdo_mysql, gd
                     tools: cs2pr
 
-            -   uses: ramsey/composer-install@v2
+            -   uses: ramsey/composer-install@v3
                 with:
                     dependency-versions: highest
 

--- a/.github/workflows/frontend-ci.yaml
+++ b/.github/workflows/frontend-ci.yaml
@@ -14,12 +14,12 @@ on:
 jobs:
     frontend-test:
         name: Frontend build test
-        runs-on: "ubuntu-20.04"
+        runs-on: "ubuntu-22.04"
         timeout-minutes: 5
 
         steps:
-            -   uses: actions/checkout@v2
-            -   uses: actions/setup-node@v2
+            -   uses: actions/checkout@v4
+            -   uses: actions/setup-node@v4
                 with:
                     node-version: '18'
             -   run: yarn install

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "ibexa-dxp"
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": " >=8.3",
         "ibexa/core": "~5.0.x-dev",
         "ibexa/doctrine-schema": "~5.0.x-dev",
         "symfony/config": "^5.4",


### PR DESCRIPTION
| :ticket: Issue | IBX-8119 |
|----------------|-----------|

#### Description:

This PR bumps the minimum required version of PHP to 8.3.
`>=8.3` version constraint is set with expectation of compatibility with version PHP 9.

Additionally, this PR:
 * enforces sorting of packages within `require` and `require-dev` sections of composer.json file
 * replaces `~5.0.0@dev` declarations with their more development friendly `~5.0.x-dev`.
 * adjusts github workflows to match new PHP version
 * updates GH action versions

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!--
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes)
-->
