### PR TITLE
IBX-8470: Upgraded codebase to Symfony 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,12 +9,12 @@
         "php": " >=8.3",
         "ibexa/core": "~5.0.x-dev",
         "ibexa/doctrine-schema": "~5.0.x-dev",
-        "symfony/config": "^5.4",
-        "symfony/dependency-injection": "^5.4",
-        "symfony/event-dispatcher": "^5.4",
-        "symfony/http-foundation": "^5.4",
-        "symfony/http-kernel": "^5.4",
-        "symfony/yaml": "^5.4"
+        "symfony/config": "^6.4",
+        "symfony/dependency-injection": "^6.4",
+        "symfony/event-dispatcher": "^6.4",
+        "symfony/http-foundation": "^6.4",
+        "symfony/http-kernel": "^6.4",
+        "symfony/yaml": "^6.4"
     },
     "require-dev": {
         "dama/doctrine-test-bundle": "^6.7",
@@ -23,7 +23,7 @@
         "phpstan/phpstan": "^1.4",
         "phpstan/phpstan-phpunit": "^1.0",
         "phpunit/phpunit": "^9.0",
-        "symfony/phpunit-bridge": "^5.4"
+        "symfony/phpunit-bridge": "^6.4"
     },
     "autoload": {
         "psr-4": {

--- a/src/bundle/DependencyInjection/IbexaCorePersistenceExtension.php
+++ b/src/bundle/DependencyInjection/IbexaCorePersistenceExtension.php
@@ -16,10 +16,12 @@ use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 
 final class IbexaCorePersistenceExtension extends Extension
 {
-    public const TAG_DOCTRINE_GATEWAY = 'ibexa.core.persistence.doctrine_gateway';
+    public const string TAG_DOCTRINE_GATEWAY = 'ibexa.core.persistence.doctrine_gateway';
 
     /**
      * @param array<string, mixed> $configs
+     *
+     * @throws \Exception
      */
     public function load(array $configs, ContainerBuilder $container): void
     {


### PR DESCRIPTION
> [!CAUTION]
> This is a part of bigger set of changes, to be merged together when ready
> - [ ] :exclamation:  **Remove TMP commits before merge** :exclamation:

| :ticket: Issue | IBX-8470 |
|----------------|-----------|


#### Related PRs:
- https://github.com/ibexa/core/pull/447
- https://github.com/ibexa/doctrine-schema/pull/27

#### Description:

This PR bumps Symfony to v6 with related codebase upgrades.

Key changes:

- [x] Bumped Symfony packages requirements to ^6.4
- [x] Added strict type to IbexaCorePersistenceExtension::TAG_DOCTRINE_GATEWAY

#### QA:

No QA required.

#### Documentation:

No documentation required.