### PR TITLE
IBX-10228: Bump symfony/* requirement to ^7.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,12 +9,12 @@
         "php": " >=8.3",
         "ibexa/core": "~5.0.x-dev",
         "ibexa/doctrine-schema": "~5.0.x-dev",
-        "symfony/config": "^7.2",
-        "symfony/dependency-injection": "^7.2",
-        "symfony/event-dispatcher": "^7.2",
-        "symfony/http-foundation": "^7.2",
-        "symfony/http-kernel": "^7.2",
-        "symfony/yaml": "^7.2"
+        "symfony/config": "^7.3",
+        "symfony/dependency-injection": "^7.3",
+        "symfony/event-dispatcher": "^7.3",
+        "symfony/http-foundation": "^7.3",
+        "symfony/http-kernel": "^7.3",
+        "symfony/yaml": "^7.3"
     },
     "require-dev": {
         "dama/doctrine-test-bundle": "^8.2",
@@ -24,7 +24,7 @@
         "phpstan/phpstan": "^2.0",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpunit/phpunit": "^9.0",
-        "symfony/phpunit-bridge": "^7.2"
+        "symfony/phpunit-bridge": "^7.3"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
| :ticket: Issue | IBX-10228    |
|----------------|--------------|

#### Description:
This PR updates all symfony/* dependencies to ^7.3.

#### For QA:
N/A

#### Documentation:
N/A

