### PR TITLE
IBX-10685: Fixed schema metadata duplication

### DIFF
--- a/src/lib/Gateway/DoctrineSchemaMetadataRegistry.php
+++ b/src/lib/Gateway/DoctrineSchemaMetadataRegistry.php
@@ -50,13 +50,16 @@ final class DoctrineSchemaMetadataRegistry implements DoctrineSchemaMetadataRegi
             $metadata = $gateway->getMetadata();
 
             $tableName = $metadata->getTableName();
-            if (isset($this->tableToMetadata[$tableName])) {
+            if (isset($this->tableToMetadata[$tableName]) && $this->tableToMetadata[$tableName] != $metadata) {
                 throw new LogicException(sprintf(
                     'Unable to register table schema metadata for "%s" table. Schema metadata is already registered.',
                     $tableName,
                 ));
             }
-            $this->tableToMetadata[$tableName] = $metadata;
+
+            if (!isset($this->tableToMetadata[$tableName])) {
+                $this->tableToMetadata[$tableName] = $metadata;
+            }
 
             $className = $metadata->getClassName();
             if ($className === null) {


### PR DESCRIPTION
| :ticket: Issue | IBX-10685|
|----------------|-----------|

"By design" we allow multiple attributes/gateways per table for custom product attributes (see https://doc.ibexa.co/en/4.6/pim/create_custom_attribute_type/ where `Attribute\Float\StorageSchema` is used for a custom attribute).
