### PR TITLE
IBX-12043: Replace deprecated getConnection()/getNotExpression() in ExpressionVisitor

### DIFF
--- a/src/contracts/Gateway/AbstractDoctrineDatabase.php
+++ b/src/contracts/Gateway/AbstractDoctrineDatabase.php
@@ -309,7 +309,8 @@ abstract class AbstractDoctrineDatabase implements GatewayInterface
             $this->registry,
             $this->getTableName(),
             $this->getTableAlias(),
-            new RelationshipTypeStrategyRegistry()
+            new RelationshipTypeStrategyRegistry(),
+            $this->connection
         );
     }
 

--- a/src/lib/Gateway/ExpressionVisitor.php
+++ b/src/lib/Gateway/ExpressionVisitor.php
@@ -50,6 +50,8 @@ final class ExpressionVisitor extends BaseExpressionVisitor
 
     private RelationshipTypeStrategyRegistryInterface $relationshipTypeStrategyRegistry;
 
+    private Connection $connection;
+
     /**
      * @param non-empty-string $tableName
      */
@@ -58,13 +60,15 @@ final class ExpressionVisitor extends BaseExpressionVisitor
         DoctrineSchemaMetadataRegistryInterface $registry,
         string $tableName,
         string $tableAlias,
-        RelationshipTypeStrategyRegistryInterface $relationshipTypeStrategyRegistry
+        RelationshipTypeStrategyRegistryInterface $relationshipTypeStrategyRegistry,
+        Connection $connection
     ) {
         $this->queryBuilder = $queryBuilder;
         $this->schemaMetadata = $registry->getMetadataForTable($tableName);
         $this->tableAlias = $tableAlias;
         $this->registry = $registry;
         $this->relationshipTypeStrategyRegistry = $relationshipTypeStrategyRegistry;
+        $this->connection = $connection;
     }
 
     /**
@@ -148,7 +152,7 @@ final class ExpressionVisitor extends BaseExpressionVisitor
                 return (string)$this->expr()->or(...$expressionList);
 
             case 'NOT':
-                return $this->queryBuilder->getConnection()->getDatabasePlatform()->getNotExpression($expressionList[0]);
+                return sprintf('NOT(%s)', $expressionList[0]);
 
             default:
                 throw new RuntimeException('Unknown composite ' . $expr->getType());
@@ -188,7 +192,7 @@ final class ExpressionVisitor extends BaseExpressionVisitor
             $toTable = $metadata->getTableName();
 
             if (DoctrineRelationship::JOIN_TYPE_SUB_SELECT === $relationship->getJoinType()) {
-                $subQuery ??= $this->queryBuilder->getConnection()->createQueryBuilder();
+                $subQuery ??= $this->connection->createQueryBuilder();
             }
 
             $this->relationshipTypeStrategyRegistry->handleRelationshipType(
@@ -219,7 +223,7 @@ final class ExpressionVisitor extends BaseExpressionVisitor
 
     private function escapeSpecialSQLValues(Parameter $parameter): string
     {
-        $platform = $this->queryBuilder->getConnection()->getDatabasePlatform();
+        $platform = $this->connection->getDatabasePlatform();
 
         return $platform->escapeStringForLike($parameter->getValue(), '\\');
     }
@@ -337,7 +341,7 @@ final class ExpressionVisitor extends BaseExpressionVisitor
         $translationMetadata = $this->schemaMetadata->getTranslationSchemaMetadata();
         $translationForeignKeyColumn = $translationMetadata->getTranslatableIdColumn();
 
-        $subquery = $this->queryBuilder->getConnection()->createQueryBuilder();
+        $subquery = $this->connection->createQueryBuilder();
         $subquery->select(self::TRANSLATION_TABLE_ALIAS . '.' . $translationForeignKeyColumn);
         $subquery->from($translationMetadata->getTableName(), self::TRANSLATION_TABLE_ALIAS);
         $subquery->where($subquery->expr()->eq(
@@ -350,7 +354,8 @@ final class ExpressionVisitor extends BaseExpressionVisitor
             $this->registry,
             $translationMetadata->getTableName(),
             self::TRANSLATION_TABLE_ALIAS,
-            $this->relationshipTypeStrategyRegistry
+            $this->relationshipTypeStrategyRegistry,
+            $this->connection
         );
         $innerCondition = $innerExpressionVisitor->walkComparison($comparison);
         $subquery->andWhere($innerCondition);

--- a/tests/bundle/Gateway/ExpressionVisitorTest.php
+++ b/tests/bundle/Gateway/ExpressionVisitorTest.php
@@ -67,7 +67,8 @@ final class ExpressionVisitorTest extends TestCase
             $this->registry,
             'table_name',
             'table_alias',
-            new RelationshipTypeStrategyRegistry()
+            new RelationshipTypeStrategyRegistry(),
+            $this->connection
         );
     }
 

--- a/tests/integration/Gateway/ExpressionVisitorTest.php
+++ b/tests/integration/Gateway/ExpressionVisitorTest.php
@@ -30,7 +30,8 @@ final class ExpressionVisitorTest extends IbexaKernelTestCase
             $registry,
             'foo_table_name',
             'foo_table_alias',
-            new RelationshipTypeStrategyRegistry()
+            new RelationshipTypeStrategyRegistry(),
+            $connection
         );
     }
 


### PR DESCRIPTION
## Why

`QueryBuilder::getConnection()` and platform `getNotExpression()` are both deprecated in DBAL 3.10 and removed in DBAL 4. Forward-compat cleanup ahead of the DBAL 4 bump — no behavior change.

## Changes

- `ExpressionVisitor.php` (public class, has an external consumer in `data-intelligence-layer`): added a `Connection $connection` constructor parameter (appended, nothing reordered/removed), replaced all 4 `$this->queryBuilder->getConnection()` call sites with `$this->connection`, and replaced the deprecated `getNotExpression()` call with portable `NOT(...)` SQL.
- Updated all in-repo `new ExpressionVisitor(...)` call sites (production + tests) to pass the new argument.

**Cross-repo note**: `data-intelligence-layer`'s `Aggregate/Gateway/DoctrineGateway::buildExpressionVisitor()` also constructs `ExpressionVisitor` and needs the same 6th argument — handled in a companion PR there. That repo's `vendor/ibexa/core-persistence` won't pick up this constructor change until this PR merges and its Composer deps are updated.

(`AbstractDoctrineDatabase.php`'s `getCountExpression()`, also originally scoped, was already fixed to portable SQL on `6.0` — no change needed.)

## Test plan

- [x] `php -l` clean on all touched files
- [x] Repo-wide grep confirms zero remaining `QueryBuilder::getConnection()`/`getNotExpression()`/`getCountExpression()` usages
- [x] `composer run test` — 27 tests, 83 assertions, all passing
- [x] `composer run test-integration` — 5 tests, 7 assertions, all passing